### PR TITLE
chore: cli redirect to stdout

### DIFF
--- a/cmd/kid/cmd/root.go
+++ b/cmd/kid/cmd/root.go
@@ -56,6 +56,9 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		Use:   "kid",
 		Short: "KiChain App",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SetOut(cmd.OutOrStdout())
+			cmd.SetErr(cmd.ErrOrStderr())
+
 			initClientCtx, err := client.ReadPersistentCommandFlags(initClientCtx, cmd.Flags())
 			if err != nil {
 				return err


### PR DESCRIPTION
```
$ kid version --long | head -n 6
name: kitools
server_name: kid
version: Mainnet-4.0.0
commit: b004902f91807096a3d3700edd862bfb711aee54
build_tags: netgo ledger,
go: go version go1.19.1 linux/amd64
```